### PR TITLE
Fix import error in main pipeline

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,12 +3,12 @@ import logging
 from datetime import datetime
 import pandas as pd
 
-# Import only the functions that exist in your paste.py file
-from paste import (
-    prepare_clustered_dataset, 
+# Import pipeline functions from the clustering module
+from clustering import (
+    prepare_clustered_dataset,
     main_matching_pipeline,
     plot_prediction_uncertainty_with_contours,
-    compute_cluster_summary, 
+    compute_cluster_summary,
     compute_pv_potential_by_cluster_year
 )
 


### PR DESCRIPTION
## Summary
- main.py referenced a non-existent `paste` module
- update main.py to import required functions from the existing `clustering` module

## Testing
- `python -m py_compile main.py`
- `python -m py_compile main.py clustering.py synergy_index.py dynamic_materials.py enhanced_thermal_model.py humidity.py data_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_68401aaa96ec8331bc67e50c1bee8c3a