### PR TITLE
Add main guard to clustering comparison

### DIFF
--- a/compare_clustering_methods.py
+++ b/compare_clustering_methods.py
@@ -179,3 +179,7 @@ def create_comparison_plots(df, X, scores):
         
     except Exception as e:
         print(f"⚠️ Could not create plots: {e}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow `compare_clustering_methods.py` to run directly by adding a main guard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846ddb247648331ac9935a0223f1f0d