### PR TITLE
Add setup script and integrate with CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,7 +28,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f scripts/setup_env.sh ]; then bash scripts/setup_env.sh; \
+        elif [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/README.md
+++ b/README.md
@@ -9,14 +9,20 @@ This repository contains a collection of scripts to process climate data and eva
 - Streamlit dashboard (`app.py`)
 
 ## Requirements
-Install dependencies from `requirements.txt` before running any of the scripts or tests:
+Install dependencies from `requirements.txt` before running any of the scripts or tests.
+You can do this manually or via the helper script in `scripts/setup_env.sh`:
 
 ```bash
+# install packages manually
 pip install -r requirements.txt
+
+# or use the setup script
+bash scripts/setup_env.sh
 ```
 
 ## Running Tests
-Unit tests use `pytest`. Ensure the dependencies are installed first, then run:
+Unit tests use `pytest`. Install the dependencies first (for example by running
+`bash scripts/setup_env.sh` as shown above), then execute:
 
 ```bash
 pytest -q

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+# Ensure pip is up to date and install dependencies
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- provide a `scripts/setup_env.sh` helper to install dependencies
- document usage of the setup script in the README
- have GitHub Actions use the setup script if available

## Testing
- `bash scripts/setup_env.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847df071070833185691144df3d638e