### PR TITLE
Implement multi-year matching pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,14 @@ python run_smarts_batch.py \
 streamlit run app.py -- --data-path matched_dataset.csv
 ```
 
+### Multi-Year PV Technology Matching
+
+Run the clustering and technology matching pipeline for several yearly datasets.
+The script looks for `clustered_dataset_<year>.csv` files in a given directory
+and produces technology-matched outputs for each year along with a combined
+file.
+
+```bash
+python multi_year_controller.py
+```
+

--- a/multi_year_controller.py
+++ b/multi_year_controller.py
@@ -1,33 +1,80 @@
 import os
-from clustering import main_matching_pipeline  # <-- REQUIRED import
+from clustering import main_matching_pipeline
 import pandas as pd
 
-# Rest of your existing code remains the same...
-def multi_year_matching_pipeline(years, base_input_path, output_dir, borders_path, k_range=range(2, 10)):
+
+def multi_year_matching_pipeline(
+    years,
+    base_input_path,
+    output_dir,
+    borders_path,
+    k_range=range(2, 10),
+):
+    """Run ``main_matching_pipeline`` across multiple yearly cluster files.
+
+    Parameters
+    ----------
+    years : list[int]
+        List of years to process.
+    base_input_path : str
+        Directory where ``clustered_dataset_<year>.csv`` files are stored.
+    output_dir : str
+        Directory to write matched datasets to.
+    borders_path : str
+        Shapefile used for mapping in ``main_matching_pipeline``.
+    k_range : range, optional
+        Range of ``k`` values to evaluate for clustering.
     """
-    Run the matching pipeline across multiple years.
-    """
+
     os.makedirs(output_dir, exist_ok=True)
 
+    results = []
+
     for year in years:
-        input_file = os.path.join(base_input_path, f"clustered_dataset_{year}.csv")
-        output_file = os.path.join(output_dir, f"matched_dataset_{year}.csv")
+        input_file = os.path.join(
+            base_input_path,
+            f"clustered_dataset_{year}.csv",
+        )
+        output_file = os.path.join(
+            output_dir,
+            f"matched_dataset_{year}.csv",
+        )
 
         print(f"\n=== Processing {year} ===")
         print(f"Input: {input_file}")
         print(f"Output: {output_file}")
-        
-        # Add your actual processing logic here
-        # For now, just copy or process the file as needed
+
+        if not os.path.exists(input_file):
+            print(f"❌ Input file not found for {year}")
+            continue
+
         try:
-            # Placeholder - replace with your actual logic
-            if os.path.exists(input_file):
-                print(f"✅ Found input file for {year}")
-                # Your processing code here
-            else:
-                print(f"❌ Input file not found for {year}")
+            df = main_matching_pipeline(
+                clustered_data_path=input_file,
+                shapefile_path=borders_path,
+                output_file=output_file,
+                k_range=k_range,
+            )
+
+            if df is not None:
+                df["Year"] = year
+                results.append(df)
         except Exception as e:
             print(f"❌ Error processing year {year}: {e}")
+
+    if results:
+        combined = pd.concat(results, ignore_index=True)
+        combined_file = os.path.join(
+            output_dir,
+            "matched_dataset_all_years.csv",
+        )
+        combined.to_csv(combined_file, index=False)
+        print(f"\n✅ Combined multi-year dataset saved to {combined_file}")
+        return combined
+
+    print("⚠️ No results generated.")
+    return None
+
 
 if __name__ == "__main__":
     years = [2020, 2021, 2022, 2023]
@@ -35,5 +82,9 @@ if __name__ == "__main__":
     output_dir = "results/matching/"
     borders_path = "data/borders/ne_10m_admin_0_countries.shp"
 
-    multi_year_matching_pipeline(years, base_input_path, output_dir, borders_path)
-
+    multi_year_matching_pipeline(
+        years,
+        base_input_path,
+        output_dir,
+        borders_path,
+    )


### PR DESCRIPTION
## Summary
- flesh out `multi_year_matching_pipeline` to run `main_matching_pipeline` for each year and combine outputs
- add README example for running multi-year matching

## Testing
- `flake8 multi_year_controller.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847df119da4833195d1120d38967f49