### PR TITLE
Fix indentation around GRIB path check

### DIFF
--- a/rc_cooling_combined_2025.py
+++ b/rc_cooling_combined_2025.py
@@ -281,8 +281,8 @@ def load_and_process_csv_files(folder_path: str,
                 chunk['time'] = pd.NaT
 
             # If GRIB path is provided, add effective_albedo column using row-wise lookup.
-                if grib_path:
-                    chunk = add_effective_albedo_optimized(chunk, grib_path)
+            if grib_path:
+                chunk = add_effective_albedo_optimized(chunk, grib_path)
             # Calculate QNET for this chunk.
             chunk['QNET'] = calculate_qnet_vectorized(chunk)
             df_list.append(chunk)


### PR DESCRIPTION
## Summary
- clean up indentation in `load_and_process_csv_files` for the GRIB path block
- ran flake8 to verify style consistency

## Testing
- `flake8 rc_cooling_combined_2025.py | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6847df1274148331981dc79254b0d722