### PR TITLE
Add database support and CLI cleanup

### DIFF
--- a/Metadata Inspection.py
+++ b/Metadata Inspection.py
@@ -46,11 +46,12 @@ def show_metadata(nc_path: str):
     ds.close()
 
 if __name__ == "__main__":
-    import os
+    import argparse
+    parser = argparse.ArgumentParser(description="Inspect NetCDF metadata")
+    parser.add_argument("nc_file", help="Path to NetCDF file")
+    args = parser.parse_args()
 
-    nc_file = r"C:\Users\gindi002\DATASET\New_Era5_dataset_netcdf\era5_2023_merged.nc"
-
-    if not os.path.exists(nc_file):
-        print(f"❌ File not found: {nc_file}")
+    if not os.path.exists(args.nc_file):
+        print(f"❌ File not found: {args.nc_file}")
     else:
-        show_metadata(nc_file)
+        show_metadata(args.nc_file)

--- a/PV prediction.py
+++ b/PV prediction.py
@@ -606,14 +606,20 @@ def rc_only_clustering(df, n_clusters=5):
 
 
 if __name__ == "__main__":
-    # Run multi-year clustering
+    import argparse
+    parser = argparse.ArgumentParser(description="Run PV prediction pipeline")
+    parser.add_argument("--input-dir", default="data/merged_years")
+    parser.add_argument("--output-dir", default="results/clusters")
+    parser.add_argument("--n-clusters", type=int, default=5)
+    parser.add_argument("--file-pattern", default="merged_dataset_*.csv")
+    args = parser.parse_args()
+
     summary = multi_year_clustering(
-        input_dir='data/merged_years',
-        output_dir='results/clusters',
-        n_clusters=5,
-        file_pattern='merged_dataset_*.csv'
+        input_dir=args.input_dir,
+        output_dir=args.output_dir,
+        n_clusters=args.n_clusters,
+        file_pattern=args.file_pattern,
     )
 
-    # Run seasonal + tech summary + plot output
     if summary is not None:
-        summarize_and_plot_multi_year_clusters(summary, output_dir='results/clusters')
+        summarize_and_plot_multi_year_clusters(summary, output_dir=args.output_dir)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ Unit tests use `pytest`. Install the dependencies first (for example by running
 pytest -q
 ```
 
+## Database Integration
+
+Several scripts can read from or write to a SQL database using SQLAlchemy. Set
+the `PV_DB_URL` environment variable or use the `--db-url` and `--db-table`
+options to enable this feature.
+
+Example using SQLite:
+
+```bash
+export PV_DB_URL=sqlite:///path/to/pv.sqlite
+python "Feature Preparation.py" --db-url $PV_DB_URL --db-table raw_pv_data
+```
+
 ## Usage
 
 Several scripts now accept file paths via command line arguments:

--- a/database_utils.py
+++ b/database_utils.py
@@ -1,0 +1,20 @@
+import os
+import pandas as pd
+from sqlalchemy import create_engine
+
+DEFAULT_DB_URL = os.getenv("PV_DB_URL", "sqlite:///pv_data.sqlite")
+
+def get_engine(db_url: str = None):
+    """Return SQLAlchemy engine using db_url or env variable."""
+    url = db_url or DEFAULT_DB_URL
+    return create_engine(url)
+
+def read_table(table_name: str, db_url: str = None):
+    """Read entire table into a DataFrame."""
+    engine = get_engine(db_url)
+    return pd.read_sql_table(table_name, engine)
+
+def write_dataframe(df: pd.DataFrame, table_name: str, db_url: str = None, if_exists: str = "replace"):
+    """Write DataFrame to table."""
+    engine = get_engine(db_url)
+    df.to_sql(table_name, engine, if_exists=if_exists, index=False)

--- a/multi_year_controller.py
+++ b/multi_year_controller.py
@@ -77,14 +77,17 @@ def multi_year_matching_pipeline(
 
 
 if __name__ == "__main__":
-    years = [2020, 2021, 2022, 2023]
-    base_input_path = "results/clusters/"
-    output_dir = "results/matching/"
-    borders_path = "data/borders/ne_10m_admin_0_countries.shp"
+    import argparse
+    parser = argparse.ArgumentParser(description="Run multi-year matching")
+    parser.add_argument("--years", nargs="+", type=int, default=[2020, 2021, 2022, 2023])
+    parser.add_argument("--base-input", default="results/clusters/")
+    parser.add_argument("--output-dir", default="results/matching/")
+    parser.add_argument("--borders-path", default="data/borders/ne_10m_admin_0_countries.shp")
+    args = parser.parse_args()
 
     multi_year_matching_pipeline(
-        years,
-        base_input_path,
-        output_dir,
-        borders_path,
+        args.years,
+        args.base_input,
+        args.output_dir,
+        args.borders_path,
     )

--- a/rc_climate_zoning.py
+++ b/rc_climate_zoning.py
@@ -217,5 +217,9 @@ def run_rc_zoning_pipeline(input_csv,
     print("✅ Pipeline complete.")
 
 if __name__ == "__main__":
-    run_rc_zoning_pipeline("input.csv")  # Replace with your actual path
+    import argparse
+    parser = argparse.ArgumentParser(description="Run RC climate zoning pipeline")
+    parser.add_argument("--input", default="input.csv", help="Path to input CSV")
+    args = parser.parse_args()
+    run_rc_zoning_pipeline(args.input)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ streamlit
 netCDF4
 pvlib
 
+sqlalchemy


### PR DESCRIPTION
## Summary
- allow database input/output in Feature Preparation
- add CLI arguments and DB integration to main pipeline
- replace hardcoded paths in various scripts with CLI options
- provide basic SQL helpers and add `sqlalchemy` to requirements
- document database usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847fabac444833194e504e828d0a1e9