### PR TITLE
Fix metrics aggregation bug and allow saving to new directories

### DIFF
--- a/rc_cooling_combined_2025.py
+++ b/rc_cooling_combined_2025.py
@@ -449,7 +449,9 @@ def aggregate_rc_metrics(kriged_file, output_file, cluster_col='Cluster_ID'):
     
     # Add cluster ID as a standalone column
     metrics_df.columns = ['Cluster_ID', 'RC_mean', 'RC_median', 'RC_std', 'RC_min', 'RC_max', 'RC_sum', 'RC_count']
-    metrics_df.drop(columns=[f"{cluster_col}_"], inplace=True)
+    drop_col = f"{cluster_col}_"
+    if drop_col in metrics_df.columns:
+        metrics_df.drop(columns=[drop_col], inplace=True)
     
     # Save the aggregated metrics
     metrics_df.to_csv(output_file, index=False)

--- a/synergy_index.py
+++ b/synergy_index.py
@@ -4,6 +4,7 @@ Created on Mon May 26 12:21:06 2025
 
 @author: Gindi002
 """
+import os
 import pandas as pd
 import numpy as np
 
@@ -111,6 +112,11 @@ def add_synergy_index_to_dataset_vectorized(csv_path, output_path=None, gamma_pv
 
     if output_path is None:
         output_path = csv_path
+
+    # Ensure output directory exists if a directory component is provided
+    output_dir = os.path.dirname(output_path)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
 
     df.to_csv(output_path, index=False)
     print(f"✅ Synergy index added and saved to: {output_path}")

--- a/tests/test_rc_aggregate.py
+++ b/tests/test_rc_aggregate.py
@@ -1,0 +1,41 @@
+import sys
+import types
+import pandas as pd
+
+
+def import_module_with_stubs():
+    """Import rc_cooling_combined_2025 with heavy dependencies stubbed."""
+    modules_to_stub = {
+        'pykrige': types.ModuleType('pykrige'),
+        'pykrige.ok': types.ModuleType('pykrige.ok'),
+        'matplotlib': types.ModuleType('matplotlib'),
+        'matplotlib.pyplot': types.ModuleType('matplotlib.pyplot'),
+        'cartopy': types.ModuleType('cartopy'),
+        'cartopy.crs': types.ModuleType('cartopy.crs'),
+        'cartopy.feature': types.ModuleType('cartopy.feature'),
+        'xarray': types.ModuleType('xarray'),
+        'geopandas': types.ModuleType('geopandas'),
+        'sklearn_extra': types.ModuleType('sklearn_extra'),
+        'sklearn_extra.cluster': types.ModuleType('sklearn_extra.cluster'),
+    }
+    modules_to_stub['pykrige.ok'].OrdinaryKriging = object
+    modules_to_stub['sklearn_extra.cluster'].KMedoids = object
+
+    for name, module in modules_to_stub.items():
+        sys.modules.setdefault(name, module)
+
+    import importlib
+    return importlib.import_module('rc_cooling_combined_2025')
+
+def test_aggregate_rc_metrics_no_error(tmp_path):
+    df = pd.DataFrame({"Cluster_ID": [1, 1, 2, 2], "RC_Kriged": [10, 20, 30, 40]})
+    kriged_file = tmp_path / "kriged.csv"
+    df.to_csv(kriged_file, index=False)
+
+    output_file = tmp_path / "metrics.csv"
+    module = import_module_with_stubs()
+    module.aggregate_rc_metrics(str(kriged_file), str(output_file))
+
+    result = pd.read_csv(output_file)
+    assert set(result.columns) >= {"Cluster_ID", "RC_mean"}
+    assert len(result) == 2

--- a/tests/test_synergy_index_output.py
+++ b/tests/test_synergy_index_output.py
@@ -1,0 +1,16 @@
+import pandas as pd
+from synergy_index import add_synergy_index_to_dataset_vectorized
+
+def test_add_synergy_index_creates_directory(tmp_path):
+    df = pd.DataFrame({"T_PV": [40], "T_RC": [30], "GHI": [1000]})
+    input_path = tmp_path / "input.csv"
+    df.to_csv(input_path, index=False)
+
+    output_dir = tmp_path / "subdir"
+    output_path = output_dir / "out.csv"
+
+    add_synergy_index_to_dataset_vectorized(str(input_path), str(output_path))
+
+    assert output_path.exists()
+    out_df = pd.read_csv(output_path)
+    assert "Synergy_Index" in out_df.columns


### PR DESCRIPTION
## Summary
- fix column drop in `aggregate_rc_metrics`
- ensure output directories exist in `add_synergy_index_to_dataset_vectorized`
- add regression tests for aggregation and output path handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848304f912c8331b07d9e451b1022db