### PR TITLE
Fix redundant writes, imports and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ python check_db_connection.py --db-url $PV_DB_URL
 
 Several scripts now accept file paths via command line arguments:
 
+**Note on quoting script names**
+Scripts whose filenames contain spaces must be wrapped in quotes when executed.
+Examples:
+
+```bash
+python "Feature Preparation.py" --help
+python "PV prediction.py" --help
+python "Spatial Mapping.py" --help
+python "Metadata Inspection.py" --help
+```
+
 ### Feature Preparation
 
 ```bash

--- a/dynamic_materials.py
+++ b/dynamic_materials.py
@@ -4,7 +4,6 @@ Created on Mon May 26 11:33:12 2025
 
 @author: Gindi002
 """
-from pvlib.solarposition import get_solarposition
 import pandas as pd
 try:
     from pvlib.solarposition import get_solarposition

--- a/rc_cooling_combined_2025.py
+++ b/rc_cooling_combined_2025.py
@@ -414,11 +414,9 @@ def multi_year_kriging(rc_folder, output_file, cluster_file=None, lat_col='latit
         df['RC_Kriged'] = z
         final_df = df
     
-    # Save final kriged data
+    # Save final kriged data once
     final_df.to_csv(output_file, index=False)
     print(f"✅ Multi-year kriged data saved to {output_file}")
-    final_df.to_csv(output_file, index=False)
-    print(f"✅ Kriged output saved to {output_file}")
 
 def aggregate_rc_metrics(kriged_file, output_file, cluster_col='Cluster_ID'):
     """
@@ -504,28 +502,22 @@ def preprocess_data(df: pd.DataFrame) -> pd.DataFrame:
     annual_stats.columns = ['LAT', 'LON', 'year', 'QNET_annual_mean', 'QNET_annual_total']
     return annual_stats
 
-""" #def compute_relative_humidity(T_air_K, T_dew_K):
- #   
-  #  Compute relative humidity (%) using the Magnus formula.
-#
- #   Parameters:
-  #      T_air_K (float or np.ndarray or pd.Series): Air temperature in Kelvin
-   #     T_dew_K (float or np.ndarray or pd.Series): Dew point temperature in Kelvin
-#
- #   Returns:
-  #      Relative humidity in percentage (0–100%)
-   # 
-    #T_air = np.array(T_air_K) - 273.15
-    #T_dew = np.array(T_dew_K) - 273.15
-
-   # a = 17.625
-    #b = 243.04
-
-    #e_s = np.exp((a * T_air) / (b + T_air))
-    #e_d = np.exp((a * T_dew) / (b + T_dew))
-    #RH = 100.0 * (e_d / e_s)
-    
-    return np.clip(RH, 0, 100)
+# def compute_relative_humidity(T_air_K, T_dew_K):
+#     """Compute relative humidity (%) using the Magnus formula."""
+#     # Parameters:
+#     #     T_air_K (float or np.ndarray or pd.Series): Air temperature in Kelvin
+#     #     T_dew_K (float or np.ndarray or pd.Series): Dew point temperature in Kelvin
+#     # Returns:
+#     #     Relative humidity in percentage (0–100%)
+#     # Example implementation (superseded by humidity.compute_relative_humidity):
+#     # T_air = np.array(T_air_K) - 273.15
+#     # T_dew = np.array(T_dew_K) - 273.15
+#     # a = 17.625
+#     # b = 243.04
+#     # e_s = np.exp((a * T_air) / (b + T_air))
+#     # e_d = np.exp((a * T_dew) / (b + T_dew))
+#     # RH = 100.0 * (e_d / e_s)
+#     # return np.clip(RH, 0, 100)
 
 def calculate_rc_with_albedo(df, albedo_values=[0.3, 0.6, 1.0]):
     results = []
@@ -534,7 +526,7 @@ def calculate_rc_with_albedo(df, albedo_values=[0.3, 0.6, 1.0]):
         df_copy['Albedo'] = alb
         df_copy = calculate_day_night_rc_power(df_copy, albedo=alb)
         results.append(df_copy)
-    return pd.concat(results) """
+    return pd.concat(results)
 
 def estimate_sky_temperature_hybrid(df):
     """


### PR DESCRIPTION
## Summary
- write kriged data once in `rc_cooling_combined_2025.py`
- convert leftover function block to regular comments
- remove duplicate solarposition import
- document quoting of script names with spaces in README

## Testing
- `pip install numpy pandas scikit-learn -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68498474bce0833195b6caae264a8e24