### PR TITLE
Simplify metrics aggregation

### DIFF
--- a/rc_cooling_combined_2025.py
+++ b/rc_cooling_combined_2025.py
@@ -446,10 +446,16 @@ def aggregate_rc_metrics(kriged_file, output_file, cluster_col='Cluster_ID'):
     metrics_df.columns = [f"{col[0]}_{col[1]}" if col[1] else col[0] for col in metrics_df.columns]
     
     # Add cluster ID as a standalone column
-    metrics_df.columns = ['Cluster_ID', 'RC_mean', 'RC_median', 'RC_std', 'RC_min', 'RC_max', 'RC_sum', 'RC_count']
-    drop_col = f"{cluster_col}_"
-    if drop_col in metrics_df.columns:
-        metrics_df.drop(columns=[drop_col], inplace=True)
+    metrics_df.columns = [
+        'Cluster_ID',
+        'RC_mean',
+        'RC_median',
+        'RC_std',
+        'RC_min',
+        'RC_max',
+        'RC_sum',
+        'RC_count',
+    ]
     
     # Save the aggregated metrics
     metrics_df.to_csv(output_file, index=False)

--- a/tests/test_rc_aggregate.py
+++ b/tests/test_rc_aggregate.py
@@ -39,3 +39,27 @@ def test_aggregate_rc_metrics_no_error(tmp_path):
     result = pd.read_csv(output_file)
     assert set(result.columns) >= {"Cluster_ID", "RC_mean"}
     assert len(result) == 2
+
+
+def test_aggregate_rc_metrics_columns(tmp_path):
+    df = pd.DataFrame({"Cluster_ID": [1, 1, 2, 2], "RC_Kriged": [5, 15, 25, 35]})
+    kriged_file = tmp_path / "kriged.csv"
+    df.to_csv(kriged_file, index=False)
+
+    output_file = tmp_path / "metrics.csv"
+    module = import_module_with_stubs()
+    module.aggregate_rc_metrics(str(kriged_file), str(output_file))
+
+    result = pd.read_csv(output_file)
+    expected = [
+        "Cluster_ID",
+        "RC_mean",
+        "RC_median",
+        "RC_std",
+        "RC_min",
+        "RC_max",
+        "RC_sum",
+        "RC_count",
+    ]
+    assert list(result.columns) == expected
+


### PR DESCRIPTION
## Summary
- drop unused column cleanup in `aggregate_rc_metrics`
- check output columns in new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c0fbb247083318e0cf09d228b8a15