### PR TITLE
Fix synergy metrics summary

### DIFF
--- a/synergy_index.py
+++ b/synergy_index.py
@@ -133,7 +133,8 @@ def calculate_synergy_metrics_summary(df, group_by_cols=None):
         group_by_cols (list): Columns to group by (e.g., ['Cluster_ID', 'season'])
     
     Returns:
-        pd.DataFrame: Summary statistics
+        pd.DataFrame: Summary statistics. When ``group_by_cols`` is ``None`` a
+        single-row DataFrame with the descriptive statistics is returned.
     """
     if 'Synergy_Index' not in df.columns:
         raise ValueError("DataFrame must contain 'Synergy_Index' column")
@@ -143,7 +144,7 @@ def calculate_synergy_metrics_summary(df, group_by_cols=None):
             'count', 'mean', 'median', 'std', 'min', 'max'
         ]).round(3)
     else:
-        summary = df['Synergy_Index'].describe()
+        summary = df['Synergy_Index'].describe().to_frame().T
     
     return summary
 

--- a/tests/test_synergy_metrics_summary.py
+++ b/tests/test_synergy_metrics_summary.py
@@ -1,0 +1,19 @@
+import pandas as pd
+from synergy_index import calculate_synergy_metrics_summary
+
+
+def test_summary_no_group():
+    df = pd.DataFrame({'Synergy_Index': [1.0, 2.0, 3.0]})
+    summary = calculate_synergy_metrics_summary(df)
+    assert isinstance(summary, pd.DataFrame)
+    assert summary['mean'].iloc[0] == 2.0
+
+
+def test_summary_grouped():
+    df = pd.DataFrame({
+        'Cluster_ID': [1, 1, 2, 2],
+        'Synergy_Index': [1.0, 2.0, 3.0, 5.0]
+    })
+    summary = calculate_synergy_metrics_summary(df, ['Cluster_ID'])
+    assert summary.loc[1, 'mean'] == 1.5
+    assert summary.loc[2, 'mean'] == 4.0


### PR DESCRIPTION
## Summary
- return a DataFrame when calculating synergy metrics without grouping
- add regression tests for non-grouped and grouped summaries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c0fb81a008331b49ffaadce15e2d7