### PR TITLE
Use context manager in metadata validator

### DIFF
--- a/grib_to_cdf_new.py
+++ b/grib_to_cdf_new.py
@@ -32,32 +32,31 @@ def validate_metadata(nc_file):
     - bool: True if the file passes validation, False otherwise.
     """
     try:
-        # Open the NetCDF file
-        ds = xr.open_dataset(nc_file)
-        
-        # Check for critical dimensions
-        required_dims = ["time", "latitude", "longitude"]
-        missing_dims = [dim for dim in required_dims if dim not in ds.dims]
-        
-        if missing_dims:
-            print(f"❌ Missing critical dimensions in {nc_file}: {missing_dims}")
-            return False
-        
-        # Check for required global attributes
-        required_attrs = ["Conventions", "title", "institution", "source"]
-        missing_attrs = [attr for attr in required_attrs if attr not in ds.attrs]
-        
-        if missing_attrs:
-            print(f"⚠️ Missing global attributes in {nc_file}: {missing_attrs}")
-            return False
-        
-        # Check for variable consistency
-        if not all(var in ds.data_vars for var in ["t2m", "sp", "u10", "v10"]):
-            print(f"⚠️ Missing expected data variables in {nc_file}")
-            return False
-        
-        print(f"✅ {nc_file} passed metadata validation.")
-        return True
+        # Open the NetCDF file within a context manager to ensure it closes
+        with xr.open_dataset(nc_file) as ds:
+            # Check for critical dimensions
+            required_dims = ["time", "latitude", "longitude"]
+            missing_dims = [dim for dim in required_dims if dim not in ds.dims]
+
+            if missing_dims:
+                print(f"❌ Missing critical dimensions in {nc_file}: {missing_dims}")
+                return False
+
+            # Check for required global attributes
+            required_attrs = ["Conventions", "title", "institution", "source"]
+            missing_attrs = [attr for attr in required_attrs if attr not in ds.attrs]
+
+            if missing_attrs:
+                print(f"⚠️ Missing global attributes in {nc_file}: {missing_attrs}")
+                return False
+
+            # Check for variable consistency
+            if not all(var in ds.data_vars for var in ["t2m", "sp", "u10", "v10"]):
+                print(f"⚠️ Missing expected data variables in {nc_file}")
+                return False
+
+            print(f"✅ {nc_file} passed metadata validation.")
+            return True
     
     except Exception as e:
         print(f"❌ Failed to validate {nc_file}: {e}")

--- a/tests/test_rc_aggregate.py
+++ b/tests/test_rc_aggregate.py
@@ -17,9 +17,14 @@ def import_module_with_stubs():
         'geopandas': types.ModuleType('geopandas'),
         'sklearn_extra': types.ModuleType('sklearn_extra'),
         'sklearn_extra.cluster': types.ModuleType('sklearn_extra.cluster'),
+        'sklearn': types.ModuleType('sklearn'),
+        'sklearn.model_selection': types.ModuleType('sklearn.model_selection'),
+        'sklearn.preprocessing': types.ModuleType('sklearn.preprocessing'),
     }
     modules_to_stub['pykrige.ok'].OrdinaryKriging = object
     modules_to_stub['sklearn_extra.cluster'].KMedoids = object
+    modules_to_stub['sklearn.model_selection'].train_test_split = lambda *a, **k: ([], [])
+    modules_to_stub['sklearn.preprocessing'].StandardScaler = object
 
     for name, module in modules_to_stub.items():
         sys.modules.setdefault(name, module)

--- a/tests/test_validate_metadata.py
+++ b/tests/test_validate_metadata.py
@@ -1,0 +1,28 @@
+import xarray as xr
+from grib_to_cdf_new import validate_metadata
+
+
+def test_validate_metadata_pass(tmp_path):
+    ds = xr.Dataset(
+        {
+            "t2m": (("time", "latitude", "longitude"), [[[280.0]]]),
+            "sp": (("time", "latitude", "longitude"), [[[1013.0]]]),
+            "u10": (("time", "latitude", "longitude"), [[[5.0]]]),
+            "v10": (("time", "latitude", "longitude"), [[[0.0]]]),
+        },
+        coords={
+            "time": [0],
+            "latitude": [10.0],
+            "longitude": [20.0],
+        },
+        attrs={
+            "Conventions": "CF-1.8",
+            "title": "Unit Test",
+            "institution": "Test Suite",
+            "source": "Synthetic",
+        },
+    )
+    path = tmp_path / "tmp.nc"
+    ds.to_netcdf(path)
+
+    assert validate_metadata(str(path)) is True


### PR DESCRIPTION
## Summary
- ensure `validate_metadata` closes datasets correctly by using a context manager
- stub sklearn in tests to avoid heavy dependency requirements
- test that `validate_metadata` validates a minimal file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c16dc33688331a781dd1bef75d0ae