### PR TITLE
Remove unused drop column logic

### DIFF
--- a/rc_cooling_combined_2025.py
+++ b/rc_cooling_combined_2025.py
@@ -447,9 +447,6 @@ def aggregate_rc_metrics(kriged_file, output_file, cluster_col='Cluster_ID'):
     
     # Add cluster ID as a standalone column
     metrics_df.columns = ['Cluster_ID', 'RC_mean', 'RC_median', 'RC_std', 'RC_min', 'RC_max', 'RC_sum', 'RC_count']
-    drop_col = f"{cluster_col}_"
-    if drop_col in metrics_df.columns:
-        metrics_df.drop(columns=[drop_col], inplace=True)
     
     # Save the aggregated metrics
     metrics_df.to_csv(output_file, index=False)

--- a/tests/test_rc_aggregate.py
+++ b/tests/test_rc_aggregate.py
@@ -15,10 +15,15 @@ def import_module_with_stubs():
         'cartopy.feature': types.ModuleType('cartopy.feature'),
         'xarray': types.ModuleType('xarray'),
         'geopandas': types.ModuleType('geopandas'),
+        'sklearn': types.ModuleType('sklearn'),
+        'sklearn.model_selection': types.ModuleType('sklearn.model_selection'),
+        'sklearn.preprocessing': types.ModuleType('sklearn.preprocessing'),
         'sklearn_extra': types.ModuleType('sklearn_extra'),
         'sklearn_extra.cluster': types.ModuleType('sklearn_extra.cluster'),
     }
     modules_to_stub['pykrige.ok'].OrdinaryKriging = object
+    modules_to_stub['sklearn.model_selection'].train_test_split = lambda *a, **k: None
+    modules_to_stub['sklearn.preprocessing'].StandardScaler = object
     modules_to_stub['sklearn_extra.cluster'].KMedoids = object
 
     for name, module in modules_to_stub.items():


### PR DESCRIPTION
## Summary
- simplify `aggregate_rc_metrics` by dropping unused `drop_col` code
- expand stubs in `test_rc_aggregate` so the module imports without scikit-learn installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c16dac26c83319c2ace7c6b84c10a