### PR TITLE
Fix synergy summary return type

### DIFF
--- a/synergy_index.py
+++ b/synergy_index.py
@@ -133,7 +133,8 @@ def calculate_synergy_metrics_summary(df, group_by_cols=None):
         group_by_cols (list): Columns to group by (e.g., ['Cluster_ID', 'season'])
     
     Returns:
-        pd.DataFrame: Summary statistics
+        pd.DataFrame: Summary statistics of ``Synergy_Index``. The result is a
+        ``DataFrame`` regardless of whether grouping is applied.
     """
     if 'Synergy_Index' not in df.columns:
         raise ValueError("DataFrame must contain 'Synergy_Index' column")
@@ -143,7 +144,7 @@ def calculate_synergy_metrics_summary(df, group_by_cols=None):
             'count', 'mean', 'median', 'std', 'min', 'max'
         ]).round(3)
     else:
-        summary = df['Synergy_Index'].describe()
+        summary = df['Synergy_Index'].describe().to_frame().T
     
     return summary
 

--- a/tests/test_rc_aggregate.py
+++ b/tests/test_rc_aggregate.py
@@ -15,11 +15,16 @@ def import_module_with_stubs():
         'cartopy.feature': types.ModuleType('cartopy.feature'),
         'xarray': types.ModuleType('xarray'),
         'geopandas': types.ModuleType('geopandas'),
+        'sklearn': types.ModuleType('sklearn'),
+        'sklearn.model_selection': types.ModuleType('sklearn.model_selection'),
+        'sklearn.preprocessing': types.ModuleType('sklearn.preprocessing'),
         'sklearn_extra': types.ModuleType('sklearn_extra'),
         'sklearn_extra.cluster': types.ModuleType('sklearn_extra.cluster'),
     }
     modules_to_stub['pykrige.ok'].OrdinaryKriging = object
     modules_to_stub['sklearn_extra.cluster'].KMedoids = object
+    modules_to_stub['sklearn.model_selection'].train_test_split = lambda *a, **k: (None, None, None, None)
+    modules_to_stub['sklearn.preprocessing'].StandardScaler = object
 
     for name, module in modules_to_stub.items():
         sys.modules.setdefault(name, module)

--- a/tests/test_synergy_metrics_summary.py
+++ b/tests/test_synergy_metrics_summary.py
@@ -1,0 +1,21 @@
+import pandas as pd
+from synergy_index import calculate_synergy_metrics_summary
+
+
+def make_df():
+    return pd.DataFrame({
+        "Synergy_Index": [1.0, 2.0, 3.0],
+        "group": ["A", "B", "A"],
+    })
+
+
+def test_metrics_summary_no_group():
+    df = make_df()
+    result = calculate_synergy_metrics_summary(df)
+    assert isinstance(result, pd.DataFrame)
+
+
+def test_metrics_summary_grouped():
+    df = make_df()
+    result = calculate_synergy_metrics_summary(df, group_by_cols=["group"])
+    assert isinstance(result, pd.DataFrame)


### PR DESCRIPTION
## Summary
- ensure `calculate_synergy_metrics_summary` returns a DataFrame
- stub extra sklearn modules in tests
- add tests for grouped and ungrouped metrics summaries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c16d75870833180ba65dfa4a44bcb