### PR TITLE
Add centralized NetCDF configuration

### DIFF
--- a/Feature Preparation.py
+++ b/Feature Preparation.py
@@ -9,6 +9,7 @@ from sklearn.metrics import mean_squared_error, mean_absolute_error, r2_score
 from sklearn.feature_selection import mutual_info_regression
 import os
 import argparse
+from config import get_nc_dir
 
 
 def parse_args():
@@ -31,7 +32,7 @@ def parse_args():
     )
     parser.add_argument(
         "--netcdf-file",
-        default="data/processed_era5/ERA5_daily.nc",
+        default=os.path.join(get_nc_dir(), "ERA5_daily.nc"),
         help="Path to processed ERA5 NetCDF file",
     )
     parser.add_argument(

--- a/Metadata Inspection.py
+++ b/Metadata Inspection.py
@@ -2,6 +2,7 @@ import os
 import xarray as xr
 import json
 from pprint import pprint
+from config import get_nc_dir
 
 def show_metadata(nc_path: str):
     """
@@ -49,10 +50,15 @@ def show_metadata(nc_path: str):
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description="Inspect NetCDF metadata")
-    parser.add_argument("nc_file", help="Path to NetCDF file")
+    parser.add_argument("nc_file", nargs="?", default=os.path.join(get_nc_dir(), "ERA5_daily.nc"),
+                        help="Path to NetCDF file")
     args = parser.parse_args()
 
-    if not os.path.exists(args.nc_file):
-        print(f"❌ File not found: {args.nc_file}")
+    nc_file = args.nc_file
+    if not os.path.isabs(nc_file):
+        nc_file = os.path.join(get_nc_dir(), nc_file)
+
+    if not os.path.exists(nc_file):
+        print(f"❌ File not found: {nc_file}")
     else:
-        show_metadata(args.nc_file)
+        show_metadata(nc_file)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ pip install -r requirements.txt
 bash scripts/setup_env.sh
 ```
 
+## NetCDF data directory
+
+Many scripts read NetCDF files from a shared location. Set the directory
+via the `NC_DATA_DIR` environment variable or create a `config.yaml` file
+with a key `nc_data_dir`. An example file is provided:
+
+```bash
+cp config.yaml.example config.yaml
+echo "nc_data_dir: /path/to/my/netcdf" > config.yaml
+```
+
+The environment variable takes precedence. Individual scripts still
+allow `--netcdf-file` arguments to override this location for a single run.
+
 ## Running Tests
 Unit tests use `pytest`. Install the dependencies first (for example by running
 `bash scripts/setup_env.sh` as shown above), then execute:
@@ -78,7 +92,8 @@ python "Feature Preparation.py" \
   --input-file data/merged_dataset.csv \
   --validated-file data/validated_dataset.csv \
   --physics-file data/physics_dataset.csv \
-  --netcdf-file data/processed_era5/ERA5_daily.nc \
+  # Optional: override the NetCDF directory
+  --netcdf-file my_dataset.nc \
   --results-dir results
 ```
 

--- a/aggregation_era5_parms_second_code.py
+++ b/aggregation_era5_parms_second_code.py
@@ -18,6 +18,7 @@ Date: May 2025
 import os
 import argparse
 import logging
+from config import get_nc_dir
 import gc
 import sys  # Add this import
 from datetime import datetime
@@ -1304,8 +1305,8 @@ def parse_arguments():
         description='Process ERA5 data: load, calculate derived variables, aggregate, and save.'
     )
     
-    parser.add_argument('--input', required=True, help='Path to ERA5 NetCDF file')
-    parser.add_argument('--output', required=True, help='Directory to save output files')
+    parser.add_argument('--input', help='Path to ERA5 NetCDF file')
+    parser.add_argument('--output', help='Directory to save output files')
     
     parser.add_argument('--lat-min', type=float, help='Minimum latitude')
     parser.add_argument('--lat-max', type=float, help='Maximum latitude')
@@ -1324,10 +1325,11 @@ def main():
     """Main entry point with hardcoded file paths."""
     # Record start time
     start_time = time.time()
-    
-    # HARDCODED PATHS - MODIFY THESE TO YOUR ACTUAL FILE LOCATIONS
-    input_file = os.getenv("ERA5_INPUT_FILE", "era5_2023_merged.nc")
-    output_dir = os.getenv("ERA5_OUTPUT_DIR", "processed_era5")
+    args = parse_arguments()
+
+    # Default locations use the shared NetCDF directory unless CLI overrides
+    input_file = args.input or os.path.join(get_nc_dir(), "era5_2023_merged.nc")
+    output_dir = args.output or os.path.join(get_nc_dir(), "processed_era5")
     
     # Optional: Hardcode spatial subset if needed
     spatial_subset = None

--- a/config.py
+++ b/config.py
@@ -1,0 +1,25 @@
+import os
+from pathlib import Path
+import yaml
+
+
+def get_nc_dir() -> str:
+    """Return directory containing NetCDF files."""
+    # 1. Environment variable takes precedence
+    env_dir = os.getenv("NC_DATA_DIR")
+    if env_dir:
+        return env_dir
+
+    # 2. config.yaml next to this file
+    config_path = Path(__file__).with_name("config.yaml")
+    if config_path.exists():
+        try:
+            with open(config_path, "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+            if isinstance(data, dict) and data.get("nc_data_dir"):
+                return str(data["nc_data_dir"])
+        except Exception:
+            pass
+
+    # 3. default
+    return "netcdf_files"

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,0 +1,1 @@
+nc_data_dir: /path/to/netcdf_files

--- a/grib_to_cdf_new.py
+++ b/grib_to_cdf_new.py
@@ -6,6 +6,7 @@ import shutil
 from tqdm import tqdm  # For progress bar
 import sys
 import cfgrib
+from config import get_nc_dir
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -13,8 +14,8 @@ logger = logging.getLogger(__name__)
 
 # Hardcoded paths - CHANGE THESE TO YOUR ACTUAL PATHS
 GRIB_FOLDER = os.getenv("GRIB_FOLDER", "grib_files")  # Directory containing GRIB files
-NETCDF_OUTPUT_FOLDER = os.getenv("NETCDF_OUTPUT_FOLDER", "netcdf_files")  # Directory for individual NetCDF files
-MERGED_NETCDF_FILE = os.getenv("MERGED_NETCDF_FILE", "era5_2023_merged.nc")  # Path for final merged file
+NETCDF_OUTPUT_FOLDER = os.getenv("NETCDF_OUTPUT_FOLDER") or get_nc_dir()
+MERGED_NETCDF_FILE = os.path.join(get_nc_dir(), os.getenv("MERGED_NETCDF_FILE", "era5_2023_merged.nc"))
 TEMP_DIR = os.getenv("TEMP_DIR", "temp")  # Temporary directory for intermediate files
 
 # Configuration

--- a/rc_cooling_combined_2025.py
+++ b/rc_cooling_combined_2025.py
@@ -7,6 +7,7 @@ import logging
 from typing import Tuple
 from sklearn.model_selection import train_test_split
 from pykrige.ok import OrdinaryKriging
+from config import get_nc_dir
 import matplotlib.pyplot as plt
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
@@ -306,7 +307,7 @@ def add_cluster_labels(rc_file, cluster_file, output_file, lat_col='latitude', l
     final_df.to_csv(output_file, index=False)
     print(f"✅ Cluster labels added and saved to {output_file}")
 
-def load_and_merge_rc_netcdf_years(folder_path, var_name='QNET', time_dim='time'):
+def load_and_merge_rc_netcdf_years(folder_path=None, var_name='QNET', time_dim='time'):
     """
     Load and merge multiple yearly RC NetCDF files into a single xarray.Dataset.
 
@@ -319,6 +320,11 @@ def load_and_merge_rc_netcdf_years(folder_path, var_name='QNET', time_dim='time'
     - ds_merged: combined xarray.Dataset with stacked time
     """
     import glob
+    if folder_path is None:
+        folder_path = get_nc_dir()
+    elif not os.path.isabs(folder_path):
+        folder_path = os.path.join(get_nc_dir(), folder_path)
+
     files = sorted(glob.glob(os.path.join(folder_path, "*.nc")))
     if not files:
         raise FileNotFoundError(f"No NetCDF files found in {folder_path}")
@@ -335,13 +341,14 @@ def load_and_merge_rc_netcdf_years(folder_path, var_name='QNET', time_dim='time'
     print(f"✅ Merged {len(datasets)} NetCDF files into one dataset")
     return ds_merged
 
-def multi_year_kriging(rc_folder, output_file, cluster_file=None, lat_col='latitude', lon_col='longitude'):
+def multi_year_kriging(rc_folder=None, output_file=None, cluster_file=None, lat_col='latitude', lon_col='longitude'):
     """
     Performs multi-year kriging to generate high-resolution RC maps.
     
     Parameters:
-    - rc_folder (str): Directory containing yearly RC CSV files.
-    - output_file (str): Path to the final merged output file.
+    - rc_folder (str or None): Directory containing yearly RC NetCDF files. If
+      None, uses ``get_nc_dir()``.
+    - output_file (str or None): Path to the final merged output file.
     - cluster_file (str): Optional path to cluster file for spatial weighting.
     - lat_col (str): Name of the latitude column.
     - lon_col (str): Name of the longitude column.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,13 @@
+import os
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _set_nc_data_dir(tmp_path, monkeypatch):
+    """Use a temporary directory for NetCDF files during tests."""
+    monkeypatch.setenv("NC_DATA_DIR", str(tmp_path))


### PR DESCRIPTION
## Summary
- add `config.py` with `get_nc_dir()` helper
- provide `config.yaml.example` for user settings
- integrate shared NetCDF directory into multiple scripts
- document environment variable/`config.yaml` workflow in README
- ensure tests set `NC_DATA_DIR` automatically

## Testing
- `pip install numpy pandas joblib pyyaml`
- `pip install scikit-learn`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c313194f883318d55704f280cdd8e