### PR TITLE
Add venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tests/__pycache__/
 # Ignore system files
 .DS_Store
 Thumbs.db
+venv/


### PR DESCRIPTION
## Summary
- ignore the local `venv` folder so that the repo stays clean after creating virtual environments

## Testing
- `python3.11 -m venv venv && source venv/bin/activate`
- `pip install -r requirements.txt`
- `python scripts/check_imports.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68512ba6cc54833186ae3590353ea081