### PR TITLE
Add flake8 configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 127
+exclude = .git,__pycache__,build,dist,venv

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Unit tests use `pytest`. Install the dependencies first (for example by running
 pytest -q
 ```
 
+This repository also uses `flake8` for linting. The configuration lives in
+`.flake8` and sets `max-line-length = 127` among other defaults.
+
 ## Database Integration
 
 Several scripts can read from or write to a SQL database using SQLAlchemy. Set


### PR DESCRIPTION
## Summary
- add `.flake8` with a 127 character line length limit
- document flake8 usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68516b3219c08331bd00f6b8e94bd52d