### PR TITLE
Resolve leftover file naming references and ignore venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ secrets.json
 __pycache__/
 tests/__pycache__/
 
+# Ignore virtual environments
+venv/
+
 # Ignore system files
 .DS_Store
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ cp tests/data/sample_clustered_dataset.csv clustered_dataset.csv
 python synergy_index.py --input clustered_dataset.csv --output results/sample_synergy.csv
 
 cp tests/data/sample_merged_dataset.csv merged_dataset.csv
-python "Feature Preparation.py" --input-file merged_dataset.csv \
+python feature_preparation.py --input-file merged_dataset.csv \
     --validated-file validated_dataset.csv --physics-file physics_dataset.csv
 ```
 


### PR DESCRIPTION
## Summary
- ignore Python virtual environments in `.gitignore`
- update README to reference renamed `feature_preparation.py` script

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68516f70a6d48331bc166994895c45ef