### PR TITLE
Remove flake8 linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 127
-exclude = .git,__pycache__,build,dist,venv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install flake8 pytest
-      - name: Lint with flake8
-        run: flake8 .
+          pip install pytest
       - name: Test with pytest
         run: pytest -q

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,15 +31,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
+        python -m pip install pytest
         if [ -f scripts/setup_env.sh ]; then bash scripts/setup_env.sh; \
         elif [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
         pytest

--- a/README.md
+++ b/README.md
@@ -112,8 +112,6 @@ pip install -r requirements.txt
 pytest
 ```
 
-This repository also uses `flake8` for linting. The configuration lives in
-`.flake8` and sets `max-line-length = 127` among other defaults.
 
 ## Database Integration
 


### PR DESCRIPTION
## Summary
- remove `.flake8` config
- drop flake8 mentions from README
- take flake8 out of CI workflows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'xarray')*

------
https://chatgpt.com/codex/tasks/task_e_6851880d9cf8833199df85756706eed4