### PR TITLE
Fix missing os import causing F821 error

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import streamlit as st
 import numpy as np
 import pandas as pd
 import argparse
+import os
 from scipy.spatial import cKDTree
 import plotly.express as px
 import plotly.graph_objects as go


### PR DESCRIPTION
## Summary
- import `os` in `app.py` so CLI arguments using `os.getenv` work

## Testing
- `scripts/setup_env.sh`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_68519e8f17d08331a6ff02aadfb0b744