### PR TITLE
Fix sklearn-extra import compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-numpy
+numpy<2
 pandas
-scikit-learn
-scikit-learn-extra
+scikit-learn==1.7.0
+scikit-learn-extra==0.3.0
 xarray
 matplotlib
 cartopy

--- a/scripts/check_imports.py
+++ b/scripts/check_imports.py
@@ -18,7 +18,10 @@ for line in req_file.read_text().splitlines():
     pkg = line.strip()
     if not pkg or pkg.startswith('#'):
         continue
-    name = pkg.split('==')[0].split('[')[0]
+    base = pkg.split('[')[0]
+    for sep in ('==', '>=', '<=', '<', '>', '~='):
+        base = base.split(sep)[0]
+    name = base
     mod_name = IMPORT_MAPPING.get(name, name.replace('-', '_'))
     try:
         import_module(mod_name)


### PR DESCRIPTION
## Summary
- pin numpy to <2 to avoid binary incompatibility with scikit-learn-extra
- pin scikit-learn and scikit-learn-extra versions
- update check_imports script to parse versioned requirement lines

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python scripts/check_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_6851d7e3bbe48331a2e08d8dc6536b57