### PR TITLE
Fix visualize_rc_maps string formatting

### DIFF
--- a/visualize_rc_maps.py
+++ b/visualize_rc_maps.py
@@ -262,52 +262,69 @@ def create_seasonal_maps(seasonal_df, output_dir, boundaries, variable):
     # Adjust layout and save
     plt.tight_layout(rect=[0, 0, 0.9, 0.96])
     variable_str = "basic" if variable == "P_rc_basic" else "net"
-    output_file = os.path.join(output_dir, f'seasonal_rc_potential_{variable_str}_{latest_year}.png')
+    output_file = os.path.join(
+        output_dir,
+        f"seasonal_rc_potential_{variable_str}_{latest_year}.png",
+    )
     plt.savefig(output_file, dpi=300, bbox_inches='tight')
     plt.close()
-    
+
     print(f"Saved seasonal {variable} map to: {output_file}")
+
 
 def main():
     """Main execution function"""
     # Parse command line arguments
     if len(sys.argv) != 4:
-        print("Usage: python visualize_rc_maps.py yearly_file.csv seasonal_file.csv output_directory")
+        print(
+            "Usage: python visualize_rc_maps.py "
+            "yearly_file.csv seasonal_file.csv output_directory"
+        )
         sys.exit(1)
-    
+
     yearly_file = sys.argv[1]
     seasonal_file = sys.argv[2]
     output_dir = sys.argv[3]
-    
+
     # Validate input files
     if not os.path.isfile(yearly_file):
-        print(f"Error: Yearly file {yearly_file} does not exist or is not a file.")
+        print(
+            f"Error: Yearly file {yearly_file} does not exist or "
+            "is not a file."
+        )
         sys.exit(1)
-    
+
     if not os.path.isfile(seasonal_file):
-        print(f"Error: Seasonal file {seasonal_file} does not exist or is not a file.")
+        print(
+            f"Error: Seasonal file {seasonal_file} does not exist or "
+            "is not a file."
+        )
         sys.exit(1)
-    
+
     # Create output directory if it doesn't exist
     os.makedirs(output_dir, exist_ok=True)
-    
+
     # Load data
-    print(f"Loading data...")
+    print("Loading data...")
     yearly_df, seasonal_df = load_data(yearly_file, seasonal_file)
-    
+
     # Get EU boundaries
     boundaries = get_eu_boundaries(yearly_df)
-    print(f"Map boundaries: Longitude [{boundaries[0]:.2f}, {boundaries[1]:.2f}], Latitude [{boundaries[2]:.2f}, {boundaries[3]:.2f}]")
-    
+    print(
+        f"Map boundaries: Longitude [{boundaries[0]:.2f}, "
+        f"{boundaries[1]:.2f}], Latitude [{boundaries[2]:.2f}, "
+        f"{boundaries[3]:.2f}]"
+    )
+
     # Create yearly maps
-    print(f"Creating yearly maps...")
+    print("Creating yearly maps...")
     create_yearly_maps(yearly_df, output_dir, boundaries)
-    
+
     # Create seasonal maps for both variables
-    print(f"Creating seasonal maps for P_rc_basic...")
+    print("Creating seasonal maps for P_rc_basic...")
     create_seasonal_maps(seasonal_df, output_dir, boundaries, 'P_rc_basic')
     
-    print(f"Creating seasonal maps for P_rc_net...")
+    print("Creating seasonal maps for P_rc_net...")
     create_seasonal_maps(seasonal_df, output_dir, boundaries, 'P_rc_net')
     
     print("All maps generated successfully!")


### PR DESCRIPTION
## Summary
- clean up f-strings that didn't use interpolation
- reformat long lines and spacing in `main`
- run flake8 on the updated section

## Testing
- `flake8 visualize_rc_maps.py | grep -E ':(27[0-9]|28[0-9]|29[0-9]|30[0-9]|31[0-9])' || echo 'no issues'`

------
https://chatgpt.com/codex/tasks/task_e_685253f0af588331b2737ff421d44af6