### PR TITLE
Initialize defaults for material parameters

### DIFF
--- a/app.py
+++ b/app.py
@@ -352,7 +352,10 @@ with st.sidebar:
         ["Custom", "Standard RC", "High-Performance RC", "Selective Emitter"],
         help="Choose a preset or select 'Custom' for manual input"
     )
-    
+
+    # Default material values to avoid uninitialized variables
+    epsilon, alpha = 0.92, 0.85
+
     if material_preset == "Custom":
         epsilon = st.slider(
             "Emissivity (ε)", 


### PR DESCRIPTION
## Summary
- set default values `epsilon, alpha = 0.92, 0.85` before the preset selection
- ensure pylint no longer warns about possibly uninitialized variables

## Testing
- `pytest -q`
- `pylint app.py`

------
https://chatgpt.com/codex/tasks/task_e_685257002f9c8331a274544d2b6e8a9b