### PR TITLE
Address import fallbacks and create output dirs

### DIFF
--- a/main.py
+++ b/main.py
@@ -258,6 +258,9 @@ def main():
         return
     mode = args.mode
 
+    # Ensure output directories exist
+    os.makedirs("results/maps", exist_ok=True)
+
     logging.info(f"🚀 Starting RC-PV pipeline in '{mode}' mode")
 
     # Check for required files

--- a/scripts/check_imports.py
+++ b/scripts/check_imports.py
@@ -5,7 +5,16 @@ from pathlib import Path
 import sys
 from packaging.requirements import Requirement
 from packaging.version import Version
-from importlib.metadata import version as get_version, PackageNotFoundError
+try:
+    from importlib.metadata import (
+        version as get_version,
+        PackageNotFoundError,
+    )
+except ImportError:  # pragma: no cover - fallback for older Python
+    from importlib_metadata import (
+        version as get_version,
+        PackageNotFoundError,
+    )
 
 req_file = Path(__file__).resolve().parent.parent / "requirements.txt"
 IMPORT_MAPPING = {

--- a/spectral_data_analysis.py
+++ b/spectral_data_analysis.py
@@ -167,6 +167,7 @@ def batch_process_smarts_outputs(input_folder, output_file):
 
     # Save combined data
     final_df = pd.DataFrame(all_data)
+    os.makedirs(os.path.dirname(output_file), exist_ok=True)
     final_df.to_csv(output_file, index=False)
     logging.info(f"✅ Combined spectral data saved to {output_file}")
 
@@ -222,6 +223,7 @@ def combine_band_data(input_folder, output_file):
             logging.info(f"❌ Failed to process {csv_file}: {e}")
 
     # Save the final combined dataset
+    os.makedirs(os.path.dirname(output_file), exist_ok=True)
     combined_df.to_csv(output_file, index=False)
     logging.info(f"✅ Combined band data saved to {output_file}")
 
@@ -250,6 +252,7 @@ def add_spectral_ratios(input_file, output_file):
         df[f"{band}_Ratio"] = df[band] / df["Total_Irradiance"]
 
     # Save the updated file
+    os.makedirs(os.path.dirname(output_file), exist_ok=True)
     df.to_csv(output_file, index=False)
     logging.info(f"✅ Spectral ratios added and saved to {output_file}")
 


### PR DESCRIPTION
## Summary
- add importlib fallback in `check_imports.py`
- ensure directories are created before writing spectral data
- create `results/maps` directory when running `main`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a254fb088331861040cdeffab2b5