### PR TITLE
Resolve pandas frequency warnings

### DIFF
--- a/rc_cooling_combined_2025.py
+++ b/rc_cooling_combined_2025.py
@@ -169,7 +169,8 @@ def add_effective_albedo_optimized(chunk, grib_path):
         return chunk
     
     # Group by unique time values to reduce GRIB file operations
-    unique_times = chunk['time'].dropna().dt.floor('H').unique()  # Round to hourly
+    # Use lower-case "h" to avoid pandas deprecation warning
+    unique_times = chunk['time'].dropna().dt.floor('h').unique()  # Round to hourly
     
     if len(unique_times) == 0:
         chunk['effective_albedo'] = DEFAULT_RHO
@@ -192,7 +193,8 @@ def add_effective_albedo_optimized(chunk, grib_path):
     
     # Apply cached values efficiently
     def get_albedo(row):
-        time_key = pd.to_datetime(row['time']).floor('H') if pd.notnull(row['time']) else None
+        # Use lower-case "h" to avoid pandas deprecation warning
+        time_key = pd.to_datetime(row['time']).floor('h') if pd.notnull(row['time']) else None
         if time_key in albedo_cache and albedo_cache[time_key] is not None:
             try:
                 albedo_data = albedo_cache[time_key]

--- a/tests/test_file_handles.py
+++ b/tests/test_file_handles.py
@@ -80,7 +80,8 @@ def test_load_netcdf_data_closes_file(tmp_path):
 
 def test_add_effective_albedo_context(monkeypatch, tmp_path):
     module = import_rc_module()
-    times = pd.date_range('2020-01-01', periods=1, freq='H')
+    # Use lower-case "h" to avoid pandas deprecation warning
+    times = pd.date_range('2020-01-01', periods=1, freq='h')
     df = pd.DataFrame({'time': times, 'LAT': [0.0], 'LON': [0.0]})
     grib_dir = tmp_path / 'grib'
     grib_dir.mkdir()


### PR DESCRIPTION
## Summary
- silence pandas warnings by switching to lower-case hourly frequency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852b6291d948331a3374a6a61bc9707