### PR TITLE
Refactor PV potential constants

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,22 @@
+"""Central configuration for physical constants and parameters."""
+
+PV_CONSTANTS = {
+    'NOCT': 45,  # Nominal Operating Cell Temperature [°C]
+    'PR_ref': 0.80,  # Reference performance ratio
+    'Reference_Red_Fraction': 0.42,  # From AM1.5 standard
+    'PR_bounds': (0.7, 0.9),  # Performance ratio bounds
+    'temperature_coefficients': {
+        'Silicon': -0.0045,
+        'Perovskite': -0.0025,
+        'Tandem': -0.0035,
+        'CdTe': -0.0028,
+    },
+}
+
+PHYSICAL_LIMITS = {
+    'GHI': (0, 1500),  # W/m²
+    'T_air': (-50, 60),  # °C
+    'RC_potential': (-100, 300),  # W/m²
+    'Red_band': (0, None),  # W/m²
+    'Total_band': (0, None),  # W/m²
+}

--- a/pv_potential.py
+++ b/pv_potential.py
@@ -1,6 +1,8 @@
 import numpy as np
 from typing import Union, Tuple
 
+from constants import PV_CONSTANTS, PHYSICAL_LIMITS
+
 
 def validate_temperature_coefficient(temp_coeff: float) -> float:
     """Validate temperature coefficient is within physical bounds."""
@@ -20,11 +22,11 @@ def validate_pv_inputs(
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Validate inputs for PV potential calculation."""
     inputs = {
-        'GHI': (GHI, 0, 1500),
-        'T_air': (T_air, -50, 60),
-        'RC_potential': (RC_potential, -100, 300),
-        'Red_band': (Red_band, 0, None),
-        'Total_band': (Total_band, 0, None),
+        'GHI': (GHI, *PHYSICAL_LIMITS['GHI']),
+        'T_air': (T_air, *PHYSICAL_LIMITS['T_air']),
+        'RC_potential': (RC_potential, *PHYSICAL_LIMITS['RC_potential']),
+        'Red_band': (Red_band, *PHYSICAL_LIMITS['Red_band']),
+        'Total_band': (Total_band, *PHYSICAL_LIMITS['Total_band']),
     }
 
     validated = {}
@@ -51,30 +53,37 @@ def calculate_pv_potential(
     RC_potential: Union[float, np.ndarray],
     Red_band: Union[float, np.ndarray],
     Total_band: Union[float, np.ndarray],
+    temp_coeff: float = PV_CONSTANTS['temperature_coefficients']['Silicon'],
 ) -> np.ndarray:
     """Calculate PV potential with validated inputs and proper error handling."""
+    # Validate temperature coefficient
+    temp_coeff = validate_temperature_coefficient(temp_coeff)
+
+    # Validate other inputs
     GHI, T_air, RC_potential, Red_band, Total_band = validate_pv_inputs(
         GHI, T_air, RC_potential, Red_band, Total_band
     )
 
-    NOCT = 45  # Nominal Operating Cell Temperature [°C]
-    Reference_Red_Fraction = 0.42  # From AM1.5 standard
-    PR_ref = 0.80  # Reference performance ratio
-
-    T_cell = T_air + (NOCT - 20) / 800 * GHI
-    Temp_Loss = -0.0045 * (T_cell - 25)
+    # Use constants from configuration
+    T_cell = T_air + (PV_CONSTANTS['NOCT'] - 20) / 800 * GHI
+    Temp_Loss = temp_coeff * (T_cell - 25)
     RC_Gain = 0.01 * (RC_potential / 50)
 
     with np.errstate(divide='ignore', invalid='ignore'):
         Actual_Red_Fraction = np.divide(
             Red_band,
             Total_band,
-            out=np.full_like(Red_band, Reference_Red_Fraction),
+            out=np.full_like(Red_band, PV_CONSTANTS['Reference_Red_Fraction']),
             where=(Total_band > 0) & ~np.isnan(Total_band),
         )
 
-    Spectral_Adjust = Actual_Red_Fraction - Reference_Red_Fraction
-    PR_corrected = np.clip(PR_ref + Temp_Loss + RC_Gain + Spectral_Adjust, 0.7, 0.9)
+    Spectral_Adjust = Actual_Red_Fraction - PV_CONSTANTS['Reference_Red_Fraction']
+    min_pr, max_pr = PV_CONSTANTS['PR_bounds']
+    PR_corrected = np.clip(
+        PV_CONSTANTS['PR_ref'] + Temp_Loss + RC_Gain + Spectral_Adjust,
+        min_pr,
+        max_pr,
+    )
 
     PV_Potential = GHI * PR_corrected
     PV_Potential = np.nan_to_num(PV_Potential, nan=0.0)

--- a/tests/test_pv_potential.py
+++ b/tests/test_pv_potential.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pytest
+
+from pv_potential import calculate_pv_potential
+from constants import PV_CONSTANTS, PHYSICAL_LIMITS
+
+
+def test_temperature_coefficient_validation():
+    """Test temperature coefficient validation."""
+    with pytest.raises(ValueError):
+        calculate_pv_potential(
+            GHI=np.array(800.0),
+            T_air=np.array(20.0),
+            RC_potential=np.array(50.0),
+            Red_band=np.array(40.0),
+            Total_band=np.array(100.0),
+            temp_coeff=-0.02,
+        )
+


### PR DESCRIPTION
## Summary
- centralize solar constants in `constants.py`
- validate inputs for PV using configuration
- update PV potential computation with configurable parameters
- simplify NetCDF PV potential calculation
- add tests for temperature coefficient validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852d1087ef08331870f112676c1a750