### PR TITLE
Update scikit-learn requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pandas>=1.3.0
 matplotlib>=3.4.0
 seaborn>=0.11.0
 xarray>=0.19.0
-scikit-learn==1.7.0
+scikit-learn>=1.2,<1.4
 scikit-learn-extra==0.3.0
 cartopy
 geopandas


### PR DESCRIPTION
## Summary
- relax pinned scikit-learn version

## Testing
- `bash scripts/setup_env.sh` *(fails: installing heavy dependencies)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'xarray')*

------
https://chatgpt.com/codex/tasks/task_e_6852e6ff3d74833193a86d8493fc3199