### PR TITLE
Add config.yaml based path management

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,23 +50,27 @@ python scripts/check_imports.py
 python scripts/check_all_imports.py
 ```
 
-## NetCDF data directory
+## Path configuration
 
-Many scripts read NetCDF files from a shared location. Set the directory
-via the `NC_DATA_DIR` environment variable or create a `config.yaml` file
-with a key `nc_data_dir`. An example file is provided:
+All file locations are now managed through a single `config.yaml` in the
+project root. Create this file and specify the paths to your datasets and
+output folders:
 
 ```bash
 cp config.yaml.example config.yaml
-echo "nc_data_dir: /path/to/my/netcdf" > config.yaml
-# Example for Windows users
-# echo "nc_data_dir: C:\Users\gindi002\DATASET\Era5_GRIB_NEW_dataset_2023-2019_and_more_future" > config.yaml
-# (This Windows path is also included as a comment in config.yaml.example.)
+cat <<EOF > config.yaml
+era5_path: /path/to/netcdf_files
+merged_data_path: /path/to/merged_dataset.csv
+pv_database_path: /path/to/pv_database.csv
+results_path: /path/to/results/
+smarts_inp_path: /path/to/smarts_inp_files/
+smarts_out_path: /path/to/smarts_out_files/
+shapefile_path: /path/to/koppen_shapefile.shp
+EOF
 ```
 
-The environment variable takes precedence. `config.yaml` is ignored by Git so you
-can adjust it locally. Individual scripts still
-allow `--netcdf-file` arguments to override this location for a single run.
+`config.yaml` is ignored by Git so you can customize paths locally. The `NC_DATA_DIR`
+environment variable still overrides `era5_path` if set.
 
 ## Input files
 

--- a/config.py
+++ b/config.py
@@ -69,20 +69,32 @@ class TrainingConfig:
         return cls(**{**cls().__dict__, **data.get("training", {})})
 
 
+@dataclass
+class PathConfig:
+    """File system paths used across the project."""
+
+    era5_path: str = "netcdf_files"
+    merged_data_path: str = "merged_dataset.csv"
+    pv_database_path: str = "pv_database.csv"
+    results_path: str = "results"
+    smarts_inp_path: str = "smarts_inp_files"
+    smarts_out_path: str = "smarts_out_files"
+    shapefile_path: str = "koppen_shapefile.shp"
+
+    @classmethod
+    def from_yaml(cls, path: Path = Path("config.yaml")) -> "PathConfig":
+        if not path.exists():
+            return cls()
+        with path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        return cls(**{**cls().__dict__, **data})
+
+
 def get_nc_dir() -> str:
     """Return directory containing NetCDF files."""
     env_dir = os.getenv("NC_DATA_DIR")
     if env_dir:
         return env_dir
 
-    config_path = Path(__file__).with_name("config.yaml")
-    if config_path.exists():
-        try:
-            with open(config_path, "r", encoding="utf-8") as f:
-                data = yaml.safe_load(f) or {}
-            if isinstance(data, Dict) and data.get("nc_data_dir"):
-                return str(data["nc_data_dir"])
-        except (OSError, yaml.YAMLError) as e:
-            print(f"Warning: could not read {config_path}: {e}")
-
-    return "netcdf_files"
+    cfg = PathConfig.from_yaml(Path("config.yaml"))
+    return cfg.era5_path

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,7 @@
+era5_path: "C:/Users/gindi002/DATASET/Era5_GRIB_NEW_dataset_2023-2019_and_more_future"
+merged_data_path: "C:/Users/gindi002/DATASET/merged_dataset.csv"
+pv_database_path: "C:/Users/gindi002/DATASET/pv_database.csv"
+results_path: "C:/Users/gindi002/PROJECT_RESULTS/"
+smarts_inp_path: "C:/Users/gindi002/DATASET/smarts_inp_files/"
+smarts_out_path: "C:/Users/gindi002/DATASET/smarts_out_files/"
+shapefile_path: "C:/Users/gindi002/DATASET/koppen_shapefile.shp"

--- a/feature_preparation.py
+++ b/feature_preparation.py
@@ -10,36 +10,38 @@ from sklearn.metrics import mean_squared_error, mean_absolute_error, r2_score
 from sklearn.feature_selection import mutual_info_regression
 import os
 import argparse
-from config import get_nc_dir
+from pathlib import Path
+from config import get_nc_dir, PathConfig
 from utils.feature_utils import filter_valid_columns, compute_band_ratios
 
 
 def parse_args():
     """Parse command line arguments for file paths."""
     parser = argparse.ArgumentParser(description="Prepare features for PV model")
+    cfg = PathConfig.from_yaml(Path("config.yaml"))
     parser.add_argument(
         "--input-file",
-        default="data/merged_dataset.csv",
+        default=cfg.merged_data_path,
         help="Path to merged dataset CSV",
     )
     parser.add_argument(
         "--validated-file",
-        default="data/validated_dataset.csv",
+        default=os.path.join(cfg.results_path, "validated_dataset.csv"),
         help="Path to save validated CSV",
     )
     parser.add_argument(
         "--physics-file",
-        default="data/physics_dataset.csv",
+        default=os.path.join(cfg.results_path, "physics_dataset.csv"),
         help="Path to save dataset with physics-based PV potential",
     )
     parser.add_argument(
         "--netcdf-file",
-        default=os.path.join(get_nc_dir(), "ERA5_daily.nc"),
+        default=os.path.join(cfg.era5_path, "ERA5_daily.nc"),
         help="Path to processed ERA5 NetCDF file",
     )
     parser.add_argument(
         "--results-dir",
-        default="results",
+        default=cfg.results_path,
         help="Directory where results will be written",
     )
     parser.add_argument(

--- a/run_smarts_batch.py
+++ b/run_smarts_batch.py
@@ -6,6 +6,7 @@ import argparse
 from pathlib import Path
 from dataclasses import dataclass
 import psutil
+from config import PathConfig
 
 
 @dataclass
@@ -37,10 +38,11 @@ class BatchConfig:
 # === USER CONFIG (overridden by CLI) ===
 def parse_args():
     """Return config-based arguments (CLI removed)."""
+    cfg = PathConfig.from_yaml(Path("config.yaml"))
     return argparse.Namespace(
         smarts_exe="smarts295bat.exe",
-        inp_dir="smarts_inp_files",
-        out_dir="smarts_out_files",
+        inp_dir=cfg.smarts_inp_path,
+        out_dir=cfg.smarts_out_path,
         timeout=300,
     )
 

--- a/setup_environment.py
+++ b/setup_environment.py
@@ -1,16 +1,17 @@
 import os
 import logging
 from pathlib import Path
+from config import PathConfig
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
+cfg = PathConfig.from_yaml(Path("config.yaml"))
 REQUIRED_DIRS = [
-    "data",
-    "results",
-    "results/maps",
-    "smarts_inp_files",
-    "smarts_out_files",
-    "spectral_analysis_output",
+    cfg.results_path,
+    os.path.join(cfg.results_path, "maps"),
+    cfg.smarts_inp_path,
+    cfg.smarts_out_path,
+    os.path.join(cfg.results_path, "spectral_analysis_output"),
 ]
 
 for d in REQUIRED_DIRS:

--- a/smarts_processor.py
+++ b/smarts_processor.py
@@ -6,6 +6,8 @@ from datetime import datetime
 import netCDF4 as nc
 import glob
 import argparse
+from pathlib import Path
+from config import PathConfig
 
 def extract_metadata(out_file_content):
     """Extract metadata from the SMARTS .out.txt file"""
@@ -328,7 +330,8 @@ def process_directory(input_dir, output_dir):
         print("-" * 60)
 
 def main():
-    input_dir = os.getenv("SMARTS_INPUT_DIR", "smarts_out_files")
+    cfg = PathConfig.from_yaml(Path("config.yaml"))
+    input_dir = cfg.smarts_out_path
     output_dir = os.getenv("SMARTS_OUTPUT_DIR", "processed_spectral")
 
     process_directory(input_dir, output_dir)

--- a/spectral_data_analysis.py
+++ b/spectral_data_analysis.py
@@ -9,6 +9,7 @@ output from SMARTS simulations.
 import os
 import argparse
 from pathlib import Path
+from config import PathConfig
 import numpy as np
 import pandas as pd
 import matplotlib
@@ -889,12 +890,12 @@ def main():
     parser = argparse.ArgumentParser(description="Process SMARTS spectral output")
     parser.add_argument(
         "--input-folder",
-        default="smarts_out_files",
+        default=PathConfig.from_yaml(Path("config.yaml")).smarts_out_path,
         help="Directory with SMARTS .ext.txt files",
     )
     parser.add_argument(
         "--output-folder",
-        default="spectral_analysis_output",
+        default=os.path.join(PathConfig.from_yaml(Path("config.yaml")).results_path, "spectral_analysis_output"),
         help="Directory for analysis output",
     )
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- add `config.yaml` with dataset paths
- centralize path handling with new `PathConfig` dataclass
- default CLI paths now load from `config.yaml`
- update setup instructions in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for required packages)*

------
https://chatgpt.com/codex/tasks/task_e_6854122f8b18833193ec334d1e68405f