### PR TITLE
Unify path config via config.yaml

### DIFF
--- a/check_db_connection.py
+++ b/check_db_connection.py
@@ -20,7 +20,9 @@ def main(db_url: str | None = None, path: str | None = None) -> int:
         engine = get_engine(url)
         with engine.connect() as conn:
             conn.execute(text("SELECT 1"))
-        logging.info("Successfully connected to the database.")
+        msg = "Successfully connected to the database."
+        print(msg)
+        logging.info(msg)
         return 0
     except (SQLAlchemyError, SynergyDatabaseError) as exc:
         logging.warning("Database connection failed: %s", exc)

--- a/config.py
+++ b/config.py
@@ -4,6 +4,27 @@ import os
 import yaml
 from typing import Dict, Any, Optional
 
+CONFIG_FILE = Path(__file__).with_name("config.yaml")
+
+
+def load_config(path: Path = CONFIG_FILE) -> Dict[str, Any]:
+    """Load configuration values from a YAML file."""
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError):
+        return {}
+
+
+CONFIG = load_config()
+
+
+def get_path(key: str, default: Optional[str] = None) -> Optional[str]:
+    """Return a configured path by key."""
+    return CONFIG.get(key, default)
+
 @dataclass
 class AppConfig:
     """Application configuration."""
@@ -75,14 +96,4 @@ def get_nc_dir() -> str:
     if env_dir:
         return env_dir
 
-    config_path = Path(__file__).with_name("config.yaml")
-    if config_path.exists():
-        try:
-            with open(config_path, "r", encoding="utf-8") as f:
-                data = yaml.safe_load(f) or {}
-            if isinstance(data, Dict) and data.get("nc_data_dir"):
-                return str(data["nc_data_dir"])
-        except (OSError, yaml.YAMLError) as e:
-            print(f"Warning: could not read {config_path}: {e}")
-
-    return "netcdf_files"
+    return get_path("era5_path", "netcdf_files")

--- a/config.yaml
+++ b/config.yaml
@@ -1,10 +1,7 @@
-number_of_clusters: 5
-ir_weight: 0.6
-temp_weight: 0.4
-input_paths:
-  era5: data/ERA5_daily.nc
-output_paths:
-  models: results/models
-  plots: results/plots
-  cluster_outputs: results/cluster_outputs
-  summaries: results/summaries
+era5_path: "C:/Users/gindi002/DATASET/Era5_GRIB_NEW_dataset_2023-2019_and_more_future"
+merged_data_path: "C:/Users/gindi002/DATASET/merged_dataset.csv"
+pv_database_path: "C:/Users/gindi002/DATASET/pv_database.csv"
+results_path: "C:/Users/gindi002/PROJECT_RESULTS/"
+smarts_inp_path: "C:/Users/gindi002/DATASET/smarts_inp_files/"
+smarts_out_path: "C:/Users/gindi002/DATASET/smarts_out_files/"
+shapefile_path: "C:/Users/gindi002/DATASET/koppen_shapefile.shp"

--- a/database_utils.py
+++ b/database_utils.py
@@ -25,8 +25,8 @@ def get_engine(db_url: str = None):
     if url.startswith("sqlite:///"):
         path = url.replace("sqlite:///", "")
         if not os.path.exists(path):
-            logging.warning("SQLite database file not found: %s", path)
-            raise SynergyDatabaseError("SQLite file does not exist", {"path": path})
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            open(path, "a").close()
     try:
         return create_engine(url)
     except Exception as exc:

--- a/feature_preparation.py
+++ b/feature_preparation.py
@@ -10,7 +10,7 @@ from sklearn.metrics import mean_squared_error, mean_absolute_error, r2_score
 from sklearn.feature_selection import mutual_info_regression
 import os
 import argparse
-from config import get_nc_dir
+from config import get_nc_dir, get_path
 from utils.feature_utils import filter_valid_columns, compute_band_ratios
 
 
@@ -19,17 +19,17 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Prepare features for PV model")
     parser.add_argument(
         "--input-file",
-        default="data/merged_dataset.csv",
+        default=get_path("merged_data_path"),
         help="Path to merged dataset CSV",
     )
     parser.add_argument(
         "--validated-file",
-        default="data/validated_dataset.csv",
+        default=os.path.join(get_path("results_path"), "validated_dataset.csv"),
         help="Path to save validated CSV",
     )
     parser.add_argument(
         "--physics-file",
-        default="data/physics_dataset.csv",
+        default=os.path.join(get_path("results_path"), "physics_dataset.csv"),
         help="Path to save dataset with physics-based PV potential",
     )
     parser.add_argument(
@@ -39,7 +39,7 @@ def parse_args():
     )
     parser.add_argument(
         "--results-dir",
-        default="results",
+        default=get_path("results_path"),
         help="Directory where results will be written",
     )
     parser.add_argument(

--- a/multi_year_controller.py
+++ b/multi_year_controller.py
@@ -3,6 +3,7 @@ import logging
 from clustering import main_matching_pipeline
 import pandas as pd
 from utils.feature_utils import save_config
+from config import get_path
 
 
 def multi_year_matching_pipeline(
@@ -113,9 +114,9 @@ if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description="Run multi-year matching")
     parser.add_argument("--years", nargs="+", type=int, default=[2020, 2021, 2022, 2023])
-    parser.add_argument("--base-input", default="results/clusters/")
-    parser.add_argument("--output-dir", default="results/matching/")
-    parser.add_argument("--borders-path", default="data/borders/ne_10m_admin_0_countries.shp")
+    parser.add_argument("--base-input", default=os.path.join(get_path("results_path"), "clusters"))
+    parser.add_argument("--output-dir", default=os.path.join(get_path("results_path"), "matching"))
+    parser.add_argument("--borders-path", default=get_path("shapefile_path"))
     parser.add_argument("--db-url", default=os.getenv("PV_DB_URL"))
     parser.add_argument("--db-table", default=os.getenv("PV_DB_TABLE", "pv_data"))
     args = parser.parse_args()

--- a/pv_prediction.py
+++ b/pv_prediction.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import joblib
 from datetime import datetime
 import os
+from config import get_path
 from xgboost import XGBRegressor
 import logging
 
@@ -97,9 +98,18 @@ def prepare_features_for_ml(df):
     return X_scaled, y, list(X.columns), scaler
 
 
-def train_random_forest(X_scaled, y, feature_names, test_size=0.2, random_state=42,
-                        n_estimators=200, max_depth=12, n_clusters=5,
-                        output_plot=None, model_dir="results/models"):
+def train_random_forest(
+    X_scaled,
+    y,
+    feature_names,
+    test_size=0.2,
+    random_state=42,
+    n_estimators=200,
+    max_depth=12,
+    n_clusters=5,
+    output_plot=None,
+    model_dir=os.path.join(get_path("results_path"), "models"),
+):
     """
     Train a Random Forest model and save the model and feature importance plot.
 
@@ -345,7 +355,7 @@ def prepare_features_for_clustering(df, feature_cols):
     return X_scaled, df_features.index
 
 
-def main_clustering_pipeline(input_file='merged_dataset.csv', output_dir='results', n_clusters=5):
+def main_clustering_pipeline(input_file=get_path('merged_data_path'), output_dir=get_path('results_path'), n_clusters=5):
     if not os.path.isfile(input_file):
         raise FileNotFoundError(f"Input file not found: {input_file}")
     df = pd.read_csv(input_file)
@@ -440,7 +450,12 @@ def main_clustering_pipeline(input_file='merged_dataset.csv', output_dir='result
 
     return df_clustered
 
-def multi_year_clustering(input_dir='.', output_dir='clustered_outputs', n_clusters=5, file_pattern='merged_dataset_*.csv'):
+def multi_year_clustering(
+    input_dir='.',
+    output_dir=os.path.join(get_path('results_path'), 'clustered_outputs'),
+    n_clusters=5,
+    file_pattern='merged_dataset_*.csv',
+):
     """
     Run main_clustering_pipeline across multiple years of merged datasets.
 
@@ -561,7 +576,7 @@ def generate_zone_descriptions(df, cluster_col='Cluster_ID'):
     return grouped[['Zone_Description']]
 
 
-def summarize_and_plot_multi_year_clusters(summary_df, output_dir='results/clusters'):
+def summarize_and_plot_multi_year_clusters(summary_df, output_dir=os.path.join(get_path('results_path'), 'clusters')):
     """
     Generate seasonal + yearly summaries and cluster maps.
     Saves summary CSVs and plots per year.
@@ -610,8 +625,8 @@ def rc_only_clustering(df, n_clusters=5):
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description="Run PV prediction pipeline")
-    parser.add_argument("--input-dir", default="data/merged_years")
-    parser.add_argument("--output-dir", default="results/clusters")
+    parser.add_argument("--input-dir", default=os.path.join(get_path("results_path"), "merged_years"))
+    parser.add_argument("--output-dir", default=os.path.join(get_path("results_path"), "clusters"))
     parser.add_argument("--n-clusters", type=int, default=5)
     parser.add_argument("--file-pattern", default="merged_dataset_*.csv")
     parser.add_argument("--db-url", default=os.getenv("PV_DB_URL"))

--- a/run_smarts_batch.py
+++ b/run_smarts_batch.py
@@ -3,6 +3,7 @@ import time
 import subprocess
 from multiprocessing import Pool, cpu_count
 import argparse
+from config import get_path
 from pathlib import Path
 from dataclasses import dataclass
 import psutil
@@ -39,8 +40,8 @@ def parse_args():
     """Return config-based arguments (CLI removed)."""
     return argparse.Namespace(
         smarts_exe="smarts295bat.exe",
-        inp_dir="smarts_inp_files",
-        out_dir="smarts_out_files",
+        inp_dir=get_path("smarts_inp_path"),
+        out_dir=get_path("smarts_out_path"),
         timeout=300,
     )
 

--- a/spatial_mapping.py
+++ b/spatial_mapping.py
@@ -8,6 +8,7 @@ import seaborn as sns
 import contextily as ctx
 from sklearn.preprocessing import StandardScaler
 from sklearn.model_selection import train_test_split
+from config import get_path
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.metrics import r2_score, mean_squared_error, mean_absolute_error, silhouette_score
 from sklearn_extra.cluster import KMedoids
@@ -399,8 +400,8 @@ if __name__ == "__main__":
     import argparse, os
 
     parser = argparse.ArgumentParser(description='PV Potential Analysis and Clustering')
-    parser.add_argument('--input', default='merged_dataset.csv', help='Input CSV file path')
-    parser.add_argument('--output', default='clustered_dataset.csv', help='Output CSV file path')
+    parser.add_argument('--input', default=get_path('merged_data_path'), help='Input CSV file path')
+    parser.add_argument('--output', default=os.path.join(get_path('results_path'), 'clustered_dataset.csv'), help='Output CSV file path')
     parser.add_argument('--clusters', type=int, default=5, help='Number of clusters for K-Medoids')
     parser.add_argument('--landmask', action='store_true', help='Apply land mask and export GeoJSON')
 
@@ -410,8 +411,9 @@ if __name__ == "__main__":
     if args.landmask:
         clustered_df = pd.read_csv(args.output)
         land_df = add_land_mask(clustered_df)
-        os.makedirs('results/clusters', exist_ok=True)
-        land_df.to_file('results/clusters/clustered_land_only.geojson', driver='GeoJSON')
+        results_dir = os.path.join(get_path('results_path'), 'clusters')
+        os.makedirs(results_dir, exist_ok=True)
+        land_df.to_file(os.path.join(results_dir, 'clustered_land_only.geojson'), driver='GeoJSON')
 
     # Main pipeline
     final_df = main_clustering_pipeline(

--- a/synergy_index.py
+++ b/synergy_index.py
@@ -7,6 +7,7 @@ Created on Mon May 26 12:21:06 2025
 import os
 import pandas as pd
 import numpy as np
+from config import get_path
 
 EMOJI_ENABLED = True
 
@@ -177,8 +178,16 @@ if __name__ == "__main__":
     from database_utils import read_table, write_dataframe
 
     parser = argparse.ArgumentParser(description="Add Synergy_Index to a dataset")
-    parser.add_argument("--input", default="clustered_dataset.csv", help="Input CSV path")
-    parser.add_argument("--output", default="clustered_dataset_synergy.csv", help="Output CSV path")
+    parser.add_argument(
+        "--input",
+        default=os.path.join(get_path("results_path"), "clustered_dataset.csv"),
+        help="Input CSV path",
+    )
+    parser.add_argument(
+        "--output",
+        default=os.path.join(get_path("results_path"), "clustered_dataset_synergy.csv"),
+        help="Output CSV path",
+    )
     parser.add_argument("--db-url", default=os.getenv("PV_DB_URL"), help="Database URL")
     parser.add_argument("--db-table", default=os.getenv("PV_DB_TABLE", "pv_data"), help="Table name for DB operations")
     parser.add_argument("--no-emoji", action="store_true", help="Disable emoji output")


### PR DESCRIPTION
## Summary
- replace sample config with verified dataset paths
- update config.py with loader and helper
- swap hardcoded paths for `get_path()`
- ensure SQLite databases are created on connect
- print DB connection success messages

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854146242a08331b1e292740bae53c9