### PR TITLE
Centralize file paths via config

### DIFF
--- a/RC_Clustering.py
+++ b/RC_Clustering.py
@@ -5,6 +5,7 @@ import geopandas as gpd
 import matplotlib.pyplot as plt
 import joblib
 import contextily as ctx
+from config import get_path
 
 from utils.sky_temperature import calculate_sky_temperature_improved
 
@@ -47,9 +48,14 @@ def rc_only_clustering(df, features=None, n_clusters=5, cluster_col='RC_Cluster'
 
     return df_out, model, score
 
-def plot_overlay_rc_pv_zones(df, rc_col='RC_Cluster', tech_col='Best_Technology',
-                              lat_col='latitude', lon_col='longitude',
-                              output_path='results/maps/overlay_rc_pv_map.png'):
+def plot_overlay_rc_pv_zones(
+    df,
+    rc_col='RC_Cluster',
+    tech_col='Best_Technology',
+    lat_col='latitude',
+    lon_col='longitude',
+    output_path=os.path.join(get_path("results_path"), "maps", "overlay_rc_pv_map.png"),
+):
     """
     Overlay RC-only clusters and matched PV technologies on the same map.
 

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import argparse
 import os
+from config import get_path
 from scipy.spatial import cKDTree
 import plotly.express as px
 import plotly.graph_objects as go
@@ -17,7 +18,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Run Streamlit PV dashboard")
     parser.add_argument(
         "--data-path",
-        default="matched_dataset.csv",
+        default=os.path.join(get_path("results_path"), "matched_dataset.csv"),
         help="Path to matched dataset CSV",
     )
     parser.add_argument("--db-url", default=os.getenv("PV_DB_URL"))

--- a/compare_clustering_methods.py
+++ b/compare_clustering_methods.py
@@ -8,6 +8,7 @@ from clustering_methods import run_kmeans, run_gmm, run_dbscan, run_agglomerativ
 from sklearn.preprocessing import StandardScaler
 import os
 import matplotlib.pyplot as plt
+from config import get_path
 from plot_utils import apply_standard_plot_style, save_figure
 from sklearn.decomposition import PCA
 
@@ -43,9 +44,10 @@ def main():
     args = parser.parse_args()
 
     n_clusters = args.k
-    input_csv = "clustered_dataset.csv"
-    output_csv = "clustered_dataset_with_methods.csv"
-    score_log = "clustering_scores.csv"
+    results_dir = get_path("results_path")
+    input_csv = os.path.join(results_dir, "clustered_dataset.csv")
+    output_csv = os.path.join(results_dir, "clustered_dataset_with_methods.csv")
+    score_log = os.path.join(results_dir, "clustering_scores.csv")
     
     # Check if input file exists
     if not os.path.exists(input_csv):

--- a/config.py
+++ b/config.py
@@ -76,10 +76,11 @@ class AppConfig:
 class TrainingConfig:
     """Paths for training datasets."""
 
-    train_features: str = "data/X_train.npy"
-    test_features: str = "data/X_test.npy"
-    train_target: str = "data/y_train.npy"
-    test_target: str = "data/y_test.npy"
+    base_dir: str = get_path("results_path")
+    train_features: str = os.path.join(base_dir, "data", "X_train.npy")
+    test_features: str = os.path.join(base_dir, "data", "X_test.npy")
+    train_target: str = os.path.join(base_dir, "data", "y_train.npy")
+    test_target: str = os.path.join(base_dir, "data", "y_test.npy")
 
     @classmethod
     def from_yaml(cls, path: Path) -> "TrainingConfig":

--- a/feature_preparation.py
+++ b/feature_preparation.py
@@ -270,7 +270,7 @@ def main_csv_workflow(input_file, validated_file, physics_file, results_dir):
 
     # --- Data Validation ---
     # Save to temp file, validate, then reload
-    temp_input = "temp_input.csv"
+    temp_input = os.path.join(results_dir, "temp_input.csv")
     df.to_csv(temp_input, index=False)
     validate_parameters(temp_input, validated_file, drop_invalid=True)
     df = pd.read_csv(validated_file)
@@ -449,7 +449,7 @@ def main():
         except Exception as e:
             logging.error(f"❌ Failed to read table {args.db_table}: {e}")
             return
-        temp_path = "db_input.csv"
+        temp_path = os.path.join(args.results_dir, "db_input.csv")
         df_db.to_csv(temp_path, index=False)
         main_csv_workflow(temp_path, args.validated_file, args.physics_file, args.results_dir)
         final_csv = os.path.join(args.results_dir, "merged_with_physics_pv.csv")

--- a/setup_environment.py
+++ b/setup_environment.py
@@ -1,16 +1,18 @@
 import os
 import logging
 from pathlib import Path
+from config import get_path
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
+results_dir = get_path("results_path")
 REQUIRED_DIRS = [
-    "data",
-    "results",
-    "results/maps",
-    "smarts_inp_files",
-    "smarts_out_files",
-    "spectral_analysis_output",
+    os.path.join(results_dir, "data"),
+    results_dir,
+    os.path.join(results_dir, "maps"),
+    get_path("smarts_inp_path"),
+    get_path("smarts_out_path"),
+    os.path.join(results_dir, "spectral_analysis_output"),
 ]
 
 for d in REQUIRED_DIRS:

--- a/smarts_processor.py
+++ b/smarts_processor.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import netCDF4 as nc
 import glob
 import argparse
+from config import get_path
 
 def extract_metadata(out_file_content):
     """Extract metadata from the SMARTS .out.txt file"""
@@ -328,8 +329,11 @@ def process_directory(input_dir, output_dir):
         print("-" * 60)
 
 def main():
-    input_dir = os.getenv("SMARTS_INPUT_DIR", "smarts_out_files")
-    output_dir = os.getenv("SMARTS_OUTPUT_DIR", "processed_spectral")
+    input_dir = os.getenv("SMARTS_INPUT_DIR", get_path("smarts_out_path"))
+    output_dir = os.getenv(
+        "SMARTS_OUTPUT_DIR",
+        os.path.join(get_path("results_path"), "processed_spectral"),
+    )
 
     process_directory(input_dir, output_dir)
 

--- a/spatial_mapping.py
+++ b/spatial_mapping.py
@@ -39,9 +39,13 @@ def add_land_mask(df, lat_col='latitude', lon_col='longitude', world_shapefile='
 
     return gdf_land
 
-def overlay_technology_matches(geo_df, tech_col='Best_Technology', cluster_col='Cluster_ID',
-                                title='Optimal PV Technologies by Location',
-                                output_path='results/maps/pv_technology_map.png'):
+def overlay_technology_matches(
+    geo_df,
+    tech_col='Best_Technology',
+    cluster_col='Cluster_ID',
+    title='Optimal PV Technologies by Location',
+    output_path=os.path.join(get_path('results_path'), 'maps', 'pv_technology_map.png'),
+):
     """
     Plot map of matched PV technologies by location.
 
@@ -78,8 +82,13 @@ def overlay_technology_matches(geo_df, tech_col='Best_Technology', cluster_col='
 
     print(f"🖼️ Saved PV technology overlay map to: {output_path}")
 
-def export_geojson(df, output_path='results/maps/final_clustered_map.geojson',
-                   lat_col='latitude', lon_col='longitude', crs_epsg=4326):
+def export_geojson(
+    df,
+    output_path=os.path.join(get_path('results_path'), 'maps', 'final_clustered_map.geojson'),
+    lat_col='latitude',
+    lon_col='longitude',
+    crs_epsg=4326,
+):
     """
     Export a DataFrame with latitude and longitude to a GeoJSON file.
 
@@ -344,7 +353,12 @@ def main_clustering_pipeline(input_file='merged_dataset.csv', output_file='clust
     
     return df_clustered
 
-def plot_prediction_uncertainty(df, lat_col='latitude', lon_col='longitude', output_path='results/maps/prediction_uncertainty_map.png'):
+def plot_prediction_uncertainty(
+    df,
+    lat_col='latitude',
+    lon_col='longitude',
+    output_path=os.path.join(get_path('results_path'), 'maps', 'prediction_uncertainty_map.png'),
+):
     """
     Plot map of prediction uncertainty from Random Forest model.
 
@@ -377,7 +391,12 @@ def plot_prediction_uncertainty(df, lat_col='latitude', lon_col='longitude', out
     print(f"🖼️ Saved prediction uncertainty map to: {output_path}")
 
 
-def plot_overlay_rc_pv_zones(df, rc_col='RC_Cluster', tech_col='Best_Technology', output_path='results/maps/rc_pv_overlay.png'):
+def plot_overlay_rc_pv_zones(
+    df,
+    rc_col='RC_Cluster',
+    tech_col='Best_Technology',
+    output_path=os.path.join(get_path('results_path'), 'maps', 'rc_pv_overlay.png'),
+):
     import geopandas as gpd
     import matplotlib.pyplot as plt
     import contextily as ctx

--- a/spectral_data_analysis.py
+++ b/spectral_data_analysis.py
@@ -18,6 +18,7 @@ import seaborn as sns
 from matplotlib.colors import LinearSegmentedColormap
 import glob
 from scipy import integrate
+from config import get_path
 import logging
 from plot_utils import apply_standard_plot_style, save_figure
 
@@ -889,12 +890,12 @@ def main():
     parser = argparse.ArgumentParser(description="Process SMARTS spectral output")
     parser.add_argument(
         "--input-folder",
-        default="smarts_out_files",
+        default=get_path("smarts_out_path"),
         help="Directory with SMARTS .ext.txt files",
     )
     parser.add_argument(
         "--output-folder",
-        default="spectral_analysis_output",
+        default=os.path.join(get_path("results_path"), "spectral_analysis_output"),
         help="Directory for analysis output",
     )
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- route all scripts to use `config.yaml` for directories
- compute dataset paths relative to `results_path`
- update environment setup and CLI defaults

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68541be210e083319f6f55d1b99550b6